### PR TITLE
Feature/move help menu #19 20

### DIFF
--- a/Config/Language/en.ps1
+++ b/Config/Language/en.ps1
@@ -334,3 +334,97 @@ Tsubokku - Japanese Translations
 
 Please contribute to this project for fame and glory!
 "
+
+function Write-Help {
+    Write-Host 
+    Write-Host "YEA Security Event Timeline Generator" -ForegroundColor Green
+    Write-Host "Version: $YEAVersion" -ForegroundColor Green
+    Write-Host "Author: Zach Mathis (@yamatosecurity)" -ForegroundColor Green
+    Write-Host 
+
+    Write-Host "Please specify some options:" 
+    Write-Host
+
+    Write-Host "Analysis Source (Specify one):"
+
+    Write-Host "   -LiveAnalysis `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Creates a timeline based on the live host's log"
+
+    Write-Host "   -LogFile <path-to-logfile>" -NoNewline -ForegroundColor Green
+    Write-Host " : Creates a timelime from an offline .evtx file"
+
+    Write-Host
+    Write-Host "Analysis Type (Specify one):"
+
+    Write-Host "   -EventIDStatistics `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output event ID statistics" 
+
+    Write-Host "   -AccountInformation `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output the usernames and SIDs of accounts"
+    
+    Write-Host "   -LogonStatistics `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output logon statistics"
+
+    Write-Host "   -LogonTimeline `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output a simple timeline of user logons"
+
+    Write-Host "   -CreateBriefHumanReadableTimeline `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Creates a human readable timeline with minimal noise"
+
+    Write-Host "   -CreateFullHumanReadableTimeline `$true" -NoNewline  -ForegroundColor Green
+    Write-Host " : Creates a human readable timeline with all details"
+
+    Write-Host 
+    Write-Host "Output Types (Default: Standard Output):"
+
+    Write-Host "   -SaveOutput <outputfile-path>" -NoNewline -ForegroundColor Green
+    Write-Host " : Output results to a text file"
+
+    Write-Host "   -OutputCSV `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Outputs to CSV (Default: `$false)"
+
+    Write-Host "   -OutputGUI `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Outputs to the Out-GridView GUI (Default: `$false)"
+
+    Write-Host 
+    Write-Host "Analysis Options:"
+
+    Write-Host "   -StartTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
+    Write-Host " : Specify the start of the timeline"
+
+    Write-Host "   -EndTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
+    Write-Host " : Specify the end of the timeline"
+
+    Write-Host "   -IsDC `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Specify if the logs are from a DC (Default: `$false)"
+
+    Write-Host 
+    Write-Host "Output Options:"
+
+    Write-Host "   -USDateFormat `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output the dates in MM-DD-YYYY format (Default: YYYY-MM-DD)"
+
+    Write-Host "   -EuropeDateFormat `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output the dates in DD-MM-YYYY format (Default: YYYY-MM-DD)"
+
+    Write-Host "   -UTC `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output in UTC time (Default: `$false)"
+    
+    Write-Host "   -DisplayTimezone `$false" -NoNewline -ForegroundColor Green
+    Write-Host " : Displays the timezone used (Default: `$true)"
+
+    Write-Host "   -ShowLogonID `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Specify if you want to see Logon IDs (Default: `$false)"
+
+    Write-Host "   -Japanese `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Output in Japanese"
+
+    Write-Host
+    Write-Host "Other:"
+
+    Write-Host "   -ShowContributors `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Show the contributors" 
+
+    Write-Host
+    
+}

--- a/Config/Language/en.ps1
+++ b/Config/Language/en.ps1
@@ -329,6 +329,7 @@ $Create_LogonTimeline_TypeOther = "Other Type Logons:"
 $Show_Contributors =
 "Contributors:
 
+oginoPmP - Developer
 DustInDark - Localization, Japanese Translations
 Tsubokku - Japanese Translations
 

--- a/Config/Language/en.ps1
+++ b/Config/Language/en.ps1
@@ -335,7 +335,7 @@ Tsubokku - Japanese Translations
 Please contribute to this project for fame and glory!
 "
 
-function Write-Help {
+function Show-Help {
     Write-Host 
     Write-Host "YEA Security Event Timeline Generator" -ForegroundColor Green
     Write-Host "Version: $YEAVersion" -ForegroundColor Green

--- a/Config/Language/ja.ps1
+++ b/Config/Language/ja.ps1
@@ -334,3 +334,92 @@ DustInDark - ローカライゼーション、和訳
 
 コントリビューターを募集しています！
 "
+
+function Write-Help {
+    
+    Write-Host 
+    Write-Host "YEAセキュリティイベントタイムライン作成ツール" -ForegroundColor Green
+    Write-Host "バージョン: $YEAVersion" -ForegroundColor Green
+    Write-Host "作者: 白舟（田中ザック） (@yamatosecurity)" -ForegroundColor Green
+    Write-Host 
+
+    Write-Host "解析ソースを一つ指定して下さい：" 
+    Write-Host "   -LiveAnalysis `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ホストOSのログでタイムラインを作成する"
+
+    Write-Host "   -LogFile <path-to-logfile>" -NoNewline -ForegroundColor Green
+    Write-Host " : オフラインの.evtxファイルでタイムラインを作成する"
+
+
+    Write-Host
+    Write-Host "解析タイプを一つ指定して下さい:"
+
+    Write-Host "   -EventIDStatistics `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : イベントIDの統計情報を出力する" 
+
+    Write-Host "   -AccountInformation `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ユーザ名とSIDのアカウント情報を出力する"
+
+    Write-Host "   -LogonStatistics `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ログオンの統計を出力する"
+
+    Write-Host "   -LogonTimeline `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ユーザログオンの簡単なタイムラインを出力する"
+
+    Write-Host "   -CreateHumanReadableTimeline `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : 読みやすいタイムラインを出力する"
+
+    Write-Host 
+    Write-Host "出力方法（デフォルト：標準出力）:"
+
+    Write-Host "   -SaveOutput <出力パス>" -NoNewline -ForegroundColor Green
+    Write-Host " : テキストファイルに出力する"
+
+    Write-Host "   -OutputGUI `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : Out-GridView GUIに出力する (デフォルト： `$false)"
+
+    Write-Host "   -OutputCSV `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : CSVファイルに出力する (デフォルト： `$false)"
+
+    Write-Host 
+    Write-Host "解析オプション:"
+
+    Write-Host "   -StartTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
+    Write-Host " : タイムラインの始まりを指定する"
+
+    Write-Host "   -EndTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
+    Write-Host " : タイムラインの終わりを指定する"
+
+    Write-Host "   -IsDC `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ドメインコントローラーのログの場合は指定して下さい (デフォルト： `$false)"
+
+    Write-Host 
+    Write-Host "出力オプション:"
+
+    Write-Host "   -USDateFormat `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)"
+
+    Write-Host "   -EuropeDateFormat `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)" 
+
+    Write-Host "   -UTC `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : 時間をUTC形式で出力する（デフォルト：`$false）"
+
+    Write-Host "   -DisplayTimezone `$false" -NoNewline -ForegroundColor Green
+    Write-Host " : ログオンIDを出力する (デフォルト： `$true)"
+
+    Write-Host "   -ShowLogonID `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : ログオンIDを出力する (デフォルト： `$false)"
+     
+    Write-Host "   -Japanese `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : 日本語で出力する"
+
+    Write-Host
+    Write-Host "その他:"
+
+    Write-Host "   -ShowContributors `$true" -NoNewline -ForegroundColor Green
+    Write-Host " : コントリビューターの一覧表示" 
+
+    Write-Host
+
+}

--- a/Config/Language/ja.ps1
+++ b/Config/Language/ja.ps1
@@ -335,7 +335,7 @@ DustInDark - ローカライゼーション、和訳
 コントリビューターを募集しています！
 "
 
-function Write-Help {
+function Show-Help {
     
     Write-Host 
     Write-Host "YEAセキュリティイベントタイムライン作成ツール" -ForegroundColor Green

--- a/Config/Language/ja.ps1
+++ b/Config/Language/ja.ps1
@@ -329,6 +329,7 @@ $Create_LogonTimeline_TypeOther = "その他のタイプのログオン:"
 $Show_Contributors =
 "コントリビューター:
 
+oginoPmP - 開発
 DustInDark - ローカライゼーション、和訳
 つぼっく - 和訳
 

--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -668,7 +668,8 @@ function Create-LogonTimeline {
                 }
 
             }
-            else { #regular logon events
+            else {
+                #regular logon events
  
                 foreach ( $EventIndex in $LogoffEventArray ) {
                 
@@ -725,7 +726,8 @@ function Create-LogonTimeline {
     
             if ($msgIpAddress -ne "-" -and #IP Address is not blank
                 !($msgTargetUserName[-1] -eq "$" -and $msgIpAddress -eq "127.0.0.1" ) -or #Not a machine account local logon
-                ($msgSubjectUserSid -eq "S-1-0-0" -and $msgTargetUserName -eq "SYSTEM")) { #To find system boot time システムの起動時間を調べるため
+                ($msgSubjectUserSid -eq "S-1-0-0" -and $msgTargetUserName -eq "SYSTEM")) {
+                #To find system boot time システムの起動時間を調べるため
                 $Timezone = Get-TimeZone
                 $TimezoneName = $Timezone.DisplayName #例：(UTC+09:00 Osaka, Sapporo, Tokyo)
                 $StartParen = $TimezoneName.IndexOf('(') #get position of (
@@ -1702,98 +1704,7 @@ if ( $LiveAnalysis -eq $false -and $LogFile -eq "" -and $EventIDStatistics -eq $
 
 if ( $LiveAnalysis -eq $false -and $LogFile -eq "" -and $EventIDStatistics -eq $false -and $LogonTimeline -eq $false -and $AccountInformation -eq $false ) {
 
-    Write-Host 
-    Write-Host "YEA Security Event Timeline Generator" -ForegroundColor Green
-    Write-Host "Version: $YEAVersion" -ForegroundColor Green
-    Write-Host "Author: Zach Mathis (@yamatosecurity)" -ForegroundColor Green
-    Write-Host 
-
-    Write-Host "Please specify some options:" 
-    Write-Host
-
-    Write-Host "Analysis Source (Specify one):"
-
-    Write-Host "   -LiveAnalysis `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Creates a timeline based on the live host's log"
-
-    Write-Host "   -LogFile <path-to-logfile>" -NoNewline -ForegroundColor Green
-    Write-Host " : Creates a timelime from an offline .evtx file"
-
-    Write-Host
-    Write-Host "Analysis Type (Specify one):"
-
-    Write-Host "   -EventIDStatistics `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output event ID statistics" 
-
-    Write-Host "   -AccountInformation `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output the usernames and SIDs of accounts"
-    
-    Write-Host "   -LogonStatistics `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output logon statistics"
-
-    Write-Host "   -LogonTimeline `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output a simple timeline of user logons"
-
-    Write-Host "   -CreateBriefHumanReadableTimeline `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Creates a human readable timeline with minimal noise"
-
-    Write-Host "   -CreateFullHumanReadableTimeline `$true" -NoNewline  -ForegroundColor Green
-    Write-Host " : Creates a human readable timeline with all details"
-
-    Write-Host 
-    Write-Host "Output Types (Default: Standard Output):"
-
-    Write-Host "   -SaveOutput <outputfile-path>" -NoNewline -ForegroundColor Green
-    Write-Host " : Output results to a text file"
-
-    Write-Host "   -OutputCSV `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Outputs to CSV (Default: `$false)"
-
-    Write-Host "   -OutputGUI `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Outputs to the Out-GridView GUI (Default: `$false)"
-
-    Write-Host 
-    Write-Host "Analysis Options:"
-
-    Write-Host "   -StartTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
-    Write-Host " : Specify the start of the timeline"
-
-    Write-Host "   -EndTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
-    Write-Host " : Specify the end of the timeline"
-
-    Write-Host "   -IsDC `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Specify if the logs are from a DC (Default: `$false)"
-
-    Write-Host 
-    Write-Host "Output Options:"
-
-    Write-Host "   -USDateFormat `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output the dates in MM-DD-YYYY format (Default: YYYY-MM-DD)"
-
-    Write-Host "   -EuropeDateFormat `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output the dates in DD-MM-YYYY format (Default: YYYY-MM-DD)"
-
-    Write-Host "   -UTC `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output in UTC time (Default: `$false)"
-    
-    Write-Host "   -DisplayTimezone `$false" -NoNewline -ForegroundColor Green
-    Write-Host " : Displays the timezone used (Default: `$true)"
-
-    Write-Host "   -ShowLogonID `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Specify if you want to see Logon IDs (Default: `$false)"
-
-    Write-Host "   -Japanese `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Output in Japanese"
-
-    Write-Host
-    Write-Host "Other:"
-
-    Write-Host "   -ShowContributors `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Show the contributors" 
-
-
-    Write-Host
-
+    Write-Help
     exit
 
 }

--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -1693,18 +1693,10 @@ if ( $LiveAnalysis -eq $true -and $LogFile -ne "" ) {
     exit
 }
 
-
-
-if ( $LiveAnalysis -eq $false -and $LogFile -eq "" -and $EventIDStatistics -eq $false -and $LogonTimeline -eq $false -and $AccountInformation -eq $false -and ($HostLanguage.Name -eq "ja-JP" -or $Japanese -eq $true) ) {
- 
-    Write-Help
-    exit
-
-}
-
+# Show-Helpは各言語のModuleに移動したためShow-Help関数は既に指定済みの言語の内容となっているため言語設定等の参照は行わない
 if ( $LiveAnalysis -eq $false -and $LogFile -eq "" -and $EventIDStatistics -eq $false -and $LogonTimeline -eq $false -and $AccountInformation -eq $false ) {
 
-    Write-Help
+    Show-Help
     exit
 
 }

--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -182,8 +182,8 @@ if ( $EuropeDateFormat -eq $true ) {
 } 
 
 function EventInfo ($eventIDNumber) {
-# TODO
-# - Add all security event IDs from https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx
+    # TODO
+    # - Add all security event IDs from https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx
     
     [hashtable]$return = @{}
 
@@ -596,8 +596,8 @@ function Create-LogonTimeline {
                     
                     "SubjectUserName" { $msgSubjectUserName = $data.'#text' } 
                     #"SubjectLogonId" { $msgSubjectLogonID = $data.'#text' }  #I was checking with Logon IDs but the duplicate 4624 event that I am filtering out later has the logon ID mapped to 4672 so will for now just check the username. 
-                                                                              #This will mess up results in the rare case that someone logs in as a normal user, adds them to the local admin group then logs in again,
-                                                                              #but will still be able to tell that that account now has admin rights or did at some point in time.
+                    #This will mess up results in the rare case that someone logs in as a normal user, adds them to the local admin group then logs in again,
+                    #but will still be able to tell that that account now has admin rights or did at some point in time.
 
                 }
             }
@@ -646,13 +646,15 @@ function Create-LogonTimeline {
 
             if ( $UTC -eq $true ) {
                 $LogonTimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff") 
-            } else {
+            }
+            else {
                 $LogonTimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
             }
 
             $LogonTimestampDateTime = [datetime]::ParseExact($LogonTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null)
 
-            if ( $msgLogonType -eq "0" ) { #if System startup/runtime
+            if ( $msgLogonType -eq "0" ) {
+                #if System startup/runtime
 
                 foreach ( $LogServiceShutdownTime in $LogServiceShutdownTimeArray ) {
 
@@ -665,8 +667,8 @@ function Create-LogonTimeline {
                     
                 }
 
-            } else #regular logon events
-            {
+            }
+            else { #regular logon events
  
                 foreach ( $EventIndex in $LogoffEventArray ) {
                 
@@ -721,10 +723,9 @@ function Create-LogonTimeline {
                          
             }
     
-            if ($msgIpAddress -ne "-" -and             #IP Address is not blank
-                !($msgTargetUserName[-1] -eq "$" -and $msgIpAddress -eq "127.0.0.1" ) -or     #Not a machine account local logon
-                ($msgSubjectUserSid -eq "S-1-0-0" -and $msgTargetUserName -eq "SYSTEM")) #To find system boot time システムの起動時間を調べるため
-            {
+            if ($msgIpAddress -ne "-" -and #IP Address is not blank
+                !($msgTargetUserName[-1] -eq "$" -and $msgIpAddress -eq "127.0.0.1" ) -or #Not a machine account local logon
+                ($msgSubjectUserSid -eq "S-1-0-0" -and $msgTargetUserName -eq "SYSTEM")) { #To find system boot time システムの起動時間を調べるため
                 $Timezone = Get-TimeZone
                 $TimezoneName = $Timezone.DisplayName #例：(UTC+09:00 Osaka, Sapporo, Tokyo)
                 $StartParen = $TimezoneName.IndexOf('(') #get position of (
@@ -769,11 +770,11 @@ function Create-LogonTimeline {
     $output = [System.Collections.ArrayList]$output #Make array mutable so we can delete duplicate logon events
 
     #重複しているログオンイベントがよくあるので、一個目（紐づいているログオフイベントがないやつ）を削除する
-    for ( $i = 0 ; $i -le  ( $output.count - 1 ) ; $i++) {
+    for ( $i = 0 ; $i -le ( $output.count - 1 ) ; $i++) {
 
-        if ( $output[$i].$Create_LogonTimeline_LogonTime -eq $output[$i+1].$Create_LogonTimeline_LogonTime -and
-             $output[$i].$Create_LogonTimeline_Type -eq $output[$i+1].$Create_LogonTimeline_Type -and
-             $output[$i].$Create_LogonTimeline_TargetUser -eq $output[$i+1].$Create_LogonTimeline_TargetUser) {
+        if ( $output[$i].$Create_LogonTimeline_LogonTime -eq $output[$i + 1].$Create_LogonTimeline_LogonTime -and
+            $output[$i].$Create_LogonTimeline_Type -eq $output[$i + 1].$Create_LogonTimeline_Type -and
+            $output[$i].$Create_LogonTimeline_TargetUser -eq $output[$i + 1].$Create_LogonTimeline_TargetUser) {
 
             $output.RemoveAt($i)
             $TotalFilteredLogons--
@@ -1694,91 +1695,7 @@ if ( $LiveAnalysis -eq $true -and $LogFile -ne "" ) {
 
 if ( $LiveAnalysis -eq $false -and $LogFile -eq "" -and $EventIDStatistics -eq $false -and $LogonTimeline -eq $false -and $AccountInformation -eq $false -and ($HostLanguage.Name -eq "ja-JP" -or $Japanese -eq $true) ) {
  
-    Write-Host 
-    Write-Host "YEAセキュリティイベントタイムライン作成ツール" -ForegroundColor Green
-    Write-Host "バージョン: $YEAVersion" -ForegroundColor Green
-    Write-Host "作者: 白舟（田中ザック） (@yamatosecurity)" -ForegroundColor Green
-    Write-Host 
-
-    Write-Host "解析ソースを一つ指定して下さい：" 
-    Write-Host "   -LiveAnalysis `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ホストOSのログでタイムラインを作成する"
-
-    Write-Host "   -LogFile <path-to-logfile>" -NoNewline -ForegroundColor Green
-    Write-Host " : オフラインの.evtxファイルでタイムラインを作成する"
-
-
-    Write-Host
-    Write-Host "解析タイプを一つ指定して下さい:"
-
-    Write-Host "   -EventIDStatistics `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : イベントIDの統計情報を出力する" 
-
-    Write-Host "   -AccountInformation `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ユーザ名とSIDのアカウント情報を出力する"
-
-    Write-Host "   -LogonStatistics `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ログオンの統計を出力する"
-
-    Write-Host "   -LogonTimeline `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ユーザログオンの簡単なタイムラインを出力する"
-
-    Write-Host "   -CreateHumanReadableTimeline `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : 読みやすいタイムラインを出力する"
-
-    Write-Host 
-    Write-Host "出力方法（デフォルト：標準出力）:"
-
-    Write-Host "   -SaveOutput <出力パス>" -NoNewline -ForegroundColor Green
-    Write-Host " : テキストファイルに出力する"
-
-    Write-Host "   -OutputGUI `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : Out-GridView GUIに出力する (デフォルト： `$false)"
-
-    Write-Host "   -OutputCSV `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : CSVファイルに出力する (デフォルト： `$false)"
-
-    Write-Host 
-    Write-Host "解析オプション:"
-
-    Write-Host "   -StartTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
-    Write-Host " : タイムラインの始まりを指定する"
-
-    Write-Host "   -EndTimeline ""<YYYY-MM-DD HH:MM:SS>""" -NoNewline -ForegroundColor Green
-    Write-Host " : タイムラインの終わりを指定する"
-
-    Write-Host "   -IsDC `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ドメインコントローラーのログの場合は指定して下さい (デフォルト： `$false)"
-
-    Write-Host 
-    Write-Host "出力オプション:"
-
-    Write-Host "   -USDateFormat `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)"
-
-    Write-Host "   -EuropeDateFormat `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)" 
-
-    Write-Host "   -UTC `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : 時間をUTC形式で出力する（デフォルト：`$false）"
-
-    Write-Host "   -DisplayTimezone `$false" -NoNewline -ForegroundColor Green
-    Write-Host " : ログオンIDを出力する (デフォルト： `$true)"
-
-    Write-Host "   -ShowLogonID `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : ログオンIDを出力する (デフォルト： `$false)"
-     
-    Write-Host "   -Japanese `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : 日本語で出力する"
-
-    Write-Host
-    Write-Host "その他:"
-
-    Write-Host "   -ShowContributors `$true" -NoNewline -ForegroundColor Green
-    Write-Host " : コントリビューターの一覧表示" 
-
-    Write-Host
-
+    Write-Help
     exit
 
 }


### PR DESCRIPTION
Helpメニューを各言語用のファイルで飛び出す関数Show-Helpを実装して以下の通り期待する結果を得られた。 #24 でのContributorを追加した

HostLanguage.Name not equal "ja-JP" or Japanese parameter is false

```
PS > .\yea-security-timeline.ps1

...
解析ソースを一つ指定して下さい：
   -LiveAnalysis $true : ホストOSのログでタイムラインを作成する
   -LogFile <path-to-logfile> : オフラインの.evtxファイルでタイムラインを作成する
   -LogDirectory <path-to-logdirectory> : 単一のフォルダに保存された複数の.evtxファイルでタイムラインを作成する

解析タイプを一つ指定して下さい:
   -EventIDStatistics $true : イベントIDの統計情報を出力する
   -AccountInformation $true : ユーザ名とSIDのアカウント情報を出力する
   -LogonStatistics $true : ログオンの統計を出力する
   -LogonTimeline $true : ユーザログオンの簡単なタイムラインを出力する
   -CreateHumanReadableTimeline $true : 読みやすいタイムラインを出力する

出力方法（デフォルト：標準出力）:
   -SaveOutput <出力パス> : テキストファイルに出力する
   -OutputGUI $true : Out-GridView GUIに出力する (デフォルト： $false)
   -OutputCSV $true : CSVファイルに出力する (デフォルト： $false)

解析オプション:
   -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの始まりを指定する
   -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの終わりを指定する
   -IsDC $true : ドメインコントローラーのログの場合は指定して下さい (デフォルト： $false)

出力オプション:
   -USDateFormat $true : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
   -EuropeDateFormat $true : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
   -UTC $true : 時間をUTC形式で出力する（デフォルト：$false）
   -DisplayTimezone $false : ログオンIDを出力する (デフォルト： $true)
   -ShowLogonID $true : ログオンIDを出力する (デフォルト： $false)
   -Japanese $true : 日本語で出力する

その他:
   -ShowContributors $true : コントリビューターの一覧表示
```

HostLanguage.Name not equal "ja-JP" and Japanese parameter is false

```

PS > .\yea-security-timeline.ps1
...
Please specify some options:

Analysis Source (Specify one):
   -LiveAnalysis $true : Creates a timeline based on the live host's log
   -LogFile <path-to-logfile> : Creates a timelime from an offline .evtx file
   -LogDirectory <path-to-logdirectory> : Creates a timeline from offline .evtx files in the directory

Analysis Type (Specify one):
   -EventIDStatistics $true : Output event ID statistics
   -AccountInformation $true : Output the usernames and SIDs of accounts
   -LogonStatistics $true : Output logon statistics
   -LogonTimeline $true : Output a simple timeline of user logons
   -CreateBriefHumanReadableTimeline $true : Creates a human readable timeline with minimal noise
   -CreateFullHumanReadableTimeline $true : Creates a human readable timeline with all details

Output Types (Default: Standard Output):
   -SaveOutput <outputfile-path> : Output results to a text file
   -OutputCSV $true : Outputs to CSV (Default: $false)
   -OutputGUI $true : Outputs to the Out-GridView GUI (Default: $false)

Analysis Options:
   -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : Specify the start of the timeline
   -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : Specify the end of the timeline
   -IsDC $true : Specify if the logs are from a DC (Default: $false)

Output Options:
   -USDateFormat $true : Output the dates in MM-DD-YYYY format (Default: YYYY-MM-DD)
   -EuropeDateFormat $true : Output the dates in DD-MM-YYYY format (Default: YYYY-MM-DD)
   -UTC $true : Output in UTC time (Default: $false)
   -DisplayTimezone $false : Displays the timezone used (Default: $true)
   -ShowLogonID $true : Specify if you want to see Logon IDs (Default: $false)
   -Japanese $true : Output in Japanese

Other:
   -ShowContributors $true : Show the contributors

```
