### PR TITLE
Feature/add statics dc kerberos log #29

### DIFF
--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -120,7 +120,7 @@ function Check-Administrator {
 
 $YEAVersion = "0.1"
 
-$EventIDsToAnalyze = "4624,4625,4672,4634,4647,4720,4732,1102,4648,4776"
+$EventIDsToAnalyze = "4624,4625,4672,4634,4647,4720,4732,1102,4648,4768,4769,4776"
 # Logs to filter for:
 # 4624 - LOGON
 # 4625 - FAILED LOGON
@@ -426,6 +426,19 @@ function Create-EventIDStatistics {
     }
 
 
+}
+
+function Get-KerberosStatusStr {
+    param(
+        $status
+    )
+    switch ( $status ) {
+        # 数は多いが有用なデータであるかどうか確認の上追記する
+        "0x0" { $msgStatusReadable = "No Error" }
+        default { $msStatusReadable = "" }
+    }
+
+    return $msgStatusReadable
 }
 
 function Create-LogonTimeline {
@@ -1080,7 +1093,6 @@ function Create-Timeline {
         $TotalLogs += 1
 
         $printMSG = ""
-
         # 4768 Kerberos authentication ticket(TGT) was requested
         if ($event.Id -eq "4768" -and $IsDC) {
             $eventXML = [xml]$event.ToXml()
@@ -1107,7 +1119,7 @@ function Create-Timeline {
                 $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
             }
 
-            $TimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $TimestampDateTime = [datetime]::ParseExact($TimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
             $timestamp = $event.TimeCreated.ToString($DateFormat) 
             $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
             $printMSG = "4768 - Requested Kerberos authentication ticket(TGT) to Service: $msgTargetService from User: $msgTargetUserName from Domain: $msgTargetDomainName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";
@@ -1116,7 +1128,7 @@ function Create-Timeline {
                     Write-Host $timestamp -NoNewline
                     Write-Host " 4768 - Requested Kerberos authentication ticket(TGT)" -NoNewline
                     Write-Host " Status " -NoNewline
-                    Write-Host $msgStatus -NoNewline -ForegroundColor $ParameterColor 
+                    Write-Host $msgResultCode -NoNewline -ForegroundColor $ParameterColor 
                     Write-Host " (" -NoNewline
                     Write-Host $msgStatusReadable -NoNewline -ForegroundColor $ParameterColor
                     Write-Host ") to Service: " -NoNewline 
@@ -1130,6 +1142,7 @@ function Create-Timeline {
                     Write-Host " Port: " -NoNewline
                     Write-Host $msgIpPort -NoNewline -ForegroundColor $ParameterColor
                     Write-Host " " -NoNewline
+                    Write-Host " ";
                 }
                 Else {
                     Write-Output "$timestamp $printMSG" | Out-File $SaveOutput -Append
@@ -1161,7 +1174,7 @@ function Create-Timeline {
                 $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
             }
 
-            $TimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $TimestampDateTime = [datetime]::ParseExact($TimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
             $timestamp = $event.TimeCreated.ToString($DateFormat) 
             $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
             $printMSG = "4769 - Requested Kerberos service ticket to Service: $msgTargetService from User: $msgTargetUserName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";
@@ -1170,7 +1183,7 @@ function Create-Timeline {
                     Write-Host $timestamp -NoNewline
                     Write-Host "  4769 - Requested Kerberos service ticket" -NoNewline
                     Write-Host " Status " -NoNewline
-                    Write-Host $msgStatus -NoNewline -ForegroundColor $ParameterColor 
+                    Write-Host $msgResultCode -NoNewline -ForegroundColor $ParameterColor 
                     Write-Host " (" -NoNewline
                     Write-Host $msgStatusReadable -NoNewline -ForegroundColor $ParameterColor
                     Write-Host ") to Service: " -NoNewline 
@@ -1182,6 +1195,7 @@ function Create-Timeline {
                     Write-Host " Port: " -NoNewline
                     Write-Host $msgIpPort -NoNewline -ForegroundColor $ParameterColor
                     Write-Host " " -NoNewline
+                    Write-Host "";
                 }
                 Else {
                     Write-Output "$timestamp $printMSG" | Out-File $SaveOutput -Append
@@ -1904,7 +1918,7 @@ foreach ( $LogFile in $evtxFiles ) {
     if ( $EventIDStatistics -eq $true ) {   
 
         Create-EventIDStatistics
-    
+        Create-Timeline
     }
     
     if ( $LogonTimeline -eq $true ) {

--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -1126,7 +1126,7 @@ function Create-Timeline {
             if ($previousMsg -ne $printMSG -and $printMSG -ne "") {
                 if ( $SaveOutput -eq "") {
                     Write-Host $timestamp -NoNewline
-                    Write-Host " 4768 - Requested Kerberos authentication ticket(TGT)" -NoNewline
+                    Write-Host "  4768 - Requested Kerberos authentication ticket(TGT)" -NoNewline
                     Write-Host " Status " -NoNewline
                     Write-Host $msgResultCode -NoNewline -ForegroundColor $ParameterColor 
                     Write-Host " (" -NoNewline

--- a/yea-security-timeline.ps1
+++ b/yea-security-timeline.ps1
@@ -131,7 +131,7 @@ $EventIDsToAnalyze = "4624,4625,4672,4634,4647,4720,4732,1102,4648,4776"
 # 4732 - User added to group
 # 1102 - LOG CLEARED
 # 4648 - EXPLICIT LOGON
-# 4776 - NTLM LOGON TO LOCAL ACCOUNT (TODO)
+# 4776 - NTLM LOGON TO LOCAL ACCOUNT
 
 # Additional logs to filter for if a DC
 # 4768 - TGT ISSUED
@@ -512,7 +512,7 @@ function Create-LogonTimeline {
 
     #Create an array of timestamps and logon IDs for logoff events
     foreach ( $event in $logs ) {
-            
+
         # 4634 Logoff
         if ($event.Id -eq "4634") { 
             
@@ -755,13 +755,13 @@ function Create-LogonTimeline {
 
             foreach ($data in $eventXML.Event.EventData.data) {
 
-                    switch ( $data.name ) {
+                switch ( $data.name ) {
 
-                        "TargetUserName" { $msgTargetUserName = $data.'#text' }
-                        "Workstation" { $msgWorkstationName = $data.'#text' }
-                        "Status" { $msgStatus = $data.'#text' }
+                    "TargetUserName" { $msgTargetUserName = $data.'#text' }
+                    "Workstation" { $msgWorkstationName = $data.'#text' }
+                    "Status" { $msgStatus = $data.'#text' }
 
-                    }
+                }
 
             }
 
@@ -798,22 +798,22 @@ function Create-LogonTimeline {
 
         }
         
-        if ($outputThisEvent -eq $TRUE ){
+        if ($outputThisEvent -eq $TRUE ) {
 
             $tempoutput = [Ordered]@{ 
-                $Create_LogonTimeline_Timezone = $UTCOffset ;
-                $Create_LogonTimeline_LogonTime = $LogonTimestampString ;
-                $Create_LogonTimeline_LogoffTime = $LogoffTimestampString ;
-                $Create_LogonTimeline_ElapsedTime = $ElapsedTimeOutput ;
-                $Create_LogonTimeline_Type = "$msgLogonType - $msgLogonTypeReadable" ;
-                $Create_LogonTimeline_Auth = $msgAuthPackageName ;
-                $Create_LogonTimeline_TargetUser = $msgTargetUserName ;
-                $Create_LogonTimeline_isAdmin = $isAdmin ;
+                $Create_LogonTimeline_Timezone          = $UTCOffset ;
+                $Create_LogonTimeline_LogonTime         = $LogonTimestampString ;
+                $Create_LogonTimeline_LogoffTime        = $LogoffTimestampString ;
+                $Create_LogonTimeline_ElapsedTime       = $ElapsedTimeOutput ;
+                $Create_LogonTimeline_Type              = "$msgLogonType - $msgLogonTypeReadable" ;
+                $Create_LogonTimeline_Auth              = $msgAuthPackageName ;
+                $Create_LogonTimeline_TargetUser        = $msgTargetUserName ;
+                $Create_LogonTimeline_isAdmin           = $isAdmin ;
                 $Create_LogonTimeline_SourceWorkstation = $msgWorkstationName ;
-                $Create_LogonTimeline_SourceIpAddress = $msgIpAddress ;
-                $Create_LogonTimeline_SourceIpPort = $msgIpPort ;
-                "Process Name" = $msgProcessName ;
-                $Create_LogonTimeline_LogonID = $msgTargetLogonID
+                $Create_LogonTimeline_SourceIpAddress   = $msgIpAddress ;
+                $Create_LogonTimeline_SourceIpPort      = $msgIpPort ;
+                "Process Name"                          = $msgProcessName ;
+                $Create_LogonTimeline_LogonID           = $msgTargetLogonID
             }
 
             if ( $DisplayTimezone -eq $false ) { $tempoutput.Remove($Create_LogonTimeline_Timezone) }
@@ -1023,7 +1023,7 @@ function Create-Timeline {
 
             }
  
-            #Bug: starttime not working: can filter on IDs when 
+            # Bug: starttime not working: can filter on IDs when 
             #$filter = "@{Logname=""Security"";ID=$EventIDsToAnalyze}"
             #and $logs = iex "Get-WinEvent -FilterHashTable $filter -Oldest -ErrorAction Stop"
             #when is change to $logs Get-WinEvent -FilterHashTable $filter -Oldest -ErrorAction Stop   I get
@@ -1081,6 +1081,113 @@ function Create-Timeline {
 
         $printMSG = ""
 
+        # 4768 Kerberos authentication ticket(TGT) was requested
+        if ($event.Id -eq "4768" -and $IsDC) {
+            $eventXML = [xml]$event.ToXml()
+
+            foreach ($data in $eventXML.Event.EventData.data) {
+            
+                switch ( $data.name ) {
+                    "TargetUserName" { $msgTargetUserName = $data.'#text' }
+                    "ServiceName" { $msgTargetService = $data.'#text' }
+                    "TargetDomainName" { $msgTargetDomainName = $data.'#text' }
+                    "IPAddress" { $msgIpAddress = $data.'#text' }
+                    "IPPort" { $msgIpPort = $data.'#text' }
+                    "Status" { $msgResultCode = $data.'#text' }
+                    "PreAuthType" { $msgPreAuthType = $data.'#text' }
+                    default { $LogNoise += 1 }
+                }
+                $TotalPiecesOfData += 1
+            }
+            
+            if ( $UTC -eq $true ) {
+                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+            }
+            else {
+                $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+            }
+
+            $TimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $timestamp = $event.TimeCreated.ToString($DateFormat) 
+            $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
+            $printMSG = "4768 - Requested Kerberos authentication ticket(TGT) to Service: $msgTargetService from User: $msgTargetUserName from Domain: $msgTargetDomainName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";
+            if ($previousMsg -ne $printMSG -and $printMSG -ne "") {
+                if ( $SaveOutput -eq "") {
+                    Write-Host $timestamp -NoNewline
+                    Write-Host " 4768 - Requested Kerberos authentication ticket(TGT)" -NoNewline
+                    Write-Host " Status " -NoNewline
+                    Write-Host $msgStatus -NoNewline -ForegroundColor $ParameterColor 
+                    Write-Host " (" -NoNewline
+                    Write-Host $msgStatusReadable -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host ") to Service: " -NoNewline 
+                    Write-Host $msgTargetService -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " from User: " -NoNewline
+                    Write-Host $msgTargetUserName -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " from Domain: " -NoNewline
+                    Write-Host $msgTargetDomainName -NoNewline -ForegroundColor $ParameterColor 
+                    Write-Host " IP address: " -NoNewline
+                    Write-Host $msgIpAddress -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " Port: " -NoNewline
+                    Write-Host $msgIpPort -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " " -NoNewline
+                }
+                Else {
+                    Write-Output "$timestamp $printMSG" | Out-File $SaveOutput -Append
+                }
+            }
+        }
+        # 4769 Kerberos service ticket was requested
+        if ($event.Id -eq "4769" -and $IsDC) {
+            $eventXML = [xml]$event.ToXml()
+
+            foreach ($data in $eventXML.Event.EventData.data) {
+            
+                switch ( $data.name ) {
+                    "TargetUserName" { $msgTargetUserName = $data.'#text' }
+                    "ServiceName" { $msgTargetService = $data.'#text' }
+                    "TargetDomainName" { $msgTargetDomainName = $data.'#text' }
+                    "IPAddress" { $msgIpAddress = $data.'#text' }
+                    "IPPort" { $msgIpPort = $data.'#text' }
+                    "Status" { $msgResultCode = $data.'#text' }
+                    default { $LogNoise += 1 }
+                }
+                $TotalPiecesOfData += 1
+            }
+            
+            if ( $UTC -eq $true ) {
+                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+            }
+            else {
+                $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+            }
+
+            $TimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $timestamp = $event.TimeCreated.ToString($DateFormat) 
+            $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
+            $printMSG = "4769 - Requested Kerberos service ticket to Service: $msgTargetService from User: $msgTargetUserName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";
+            if ($previousMsg -ne $printMSG -and $printMSG -ne "") {
+                if ( $SaveOutput -eq "") {
+                    Write-Host $timestamp -NoNewline
+                    Write-Host "  4769 - Requested Kerberos service ticket" -NoNewline
+                    Write-Host " Status " -NoNewline
+                    Write-Host $msgStatus -NoNewline -ForegroundColor $ParameterColor 
+                    Write-Host " (" -NoNewline
+                    Write-Host $msgStatusReadable -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host ") to Service: " -NoNewline 
+                    Write-Host $msgTargetService -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " from User: " -NoNewline
+                    Write-Host $msgTargetUserName -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " IP address: " -NoNewline
+                    Write-Host $msgIpAddress -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " Port: " -NoNewline
+                    Write-Host $msgIpPort -NoNewline -ForegroundColor $ParameterColor
+                    Write-Host " " -NoNewline
+                }
+                Else {
+                    Write-Output "$timestamp $printMSG" | Out-File $SaveOutput -Append
+                }
+            }            
+        }
         #Successful logon
         if ($event.Id -eq "4624") { 
 


### PR DESCRIPTION
closes #29 

## 変更点
- EventIDStatics が trueの時、以下のイベントIDを検知し各種情報を出力するようにした
  - SecurityログEventID 4768
  - SecurityログEventID 4769
  
## 出力結果

テストに用いたログは別方法で共有。

> PS > ..\yea-security-timeline.ps1 -LogFile .\Kerberoasting.evtx -IsDC $true -EventIDStatistics $true
> 
> イベントIDを集計します。
> 少々お待ちください。    
> 
> イベントの合計: 6
> ファイルサイズ: 68.00 kB
> 最初のイベント: 2021-04-29 18:23:54.24
> 最後のイベント: 2021-04-29 18:23:58.73
> 
> 処理時間：0時0分0秒
> 
> Creating timeline for .\Kerberoasting.evtx
> File Size: 68.00 kB
> Please be patient. It should take approximately: 0 hours 0 minutes 0 seconds
> 
> 2021-04-29 18:23:54.24  1102 - EVENT LOG CLEARED
(中略)
> 2021-04-29 18:23:58.71 4768 - Requested Kerberos authentication ticket(TGT) Status 0x0 (No Error) to Service: krbtgt from User: Alice from Domain: LABCORP.LOCAL IP address: ::ffff:192.168.1.200 Port: 55976
> 2021-04-29 18:23:58.72  4769 - Requested Kerberos service ticket Status 0x0 (No Error) to Service: sql101 from User: Alice@LABCORP.LOCAL IP address: ::ffff:192.168.1.200 Port: 55978
> (中略)
> Total analyzed logs: 6
> Useless logs: 1
> Alerted events: 3
> Log event data reduction: 50%
> 
> Useful Data in filtered logs: 22
> Noisy Data in filtered logs: 35
> Log Noise: 61.4%
> 
> カウント      ID   イベント              タイムライン出力
> ----      --   ----              --------
> 1 (16.7%) 1102 イベントログがクリアされた     Yes
> 1 (16.7%) 4634 ログオフ              Yes
> 1 (16.7%) 4768 不明
> 1 (16.7%) 4624 アカウントログオン         Yes
> 1 (16.7%) 4769 不明
> 1 (16.7%) 4776 ローカルユーザへのNTLMログオン
> Processing time: 0 hours 0 minutes 0 seconds
