### PR TITLE
Feature/outputlogo#41

### DIFF
--- a/Config/Language/en.ps1
+++ b/Config/Language/en.ps1
@@ -414,6 +414,9 @@ function Show-Help {
     Write-Host "   -ShowContributors" -NoNewline -ForegroundColor Green
     Write-Host " : Show the contributors" 
 
+    Write-Host "   -QuietLogo" -NoNewline -ForegroundColor Green
+    Write-Host " : Hide Execute WELA Logo" 
+
     Write-Host
     
 }

--- a/Config/Language/ja.ps1
+++ b/Config/Language/ja.ps1
@@ -390,7 +390,7 @@ function Show-Help {
     Write-Host "   -USDateFormat" -NoNewline -ForegroundColor Green
     Write-Host " : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)"
 
-    Write-Host "   -EuropeDateFormat `$true" -NoNewline -ForegroundColor Green
+    Write-Host "   -EuropeDateFormat" -NoNewline -ForegroundColor Green
     Write-Host " : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)" 
 
     Write-Host "   -UTC" -NoNewline -ForegroundColor Green
@@ -402,13 +402,13 @@ function Show-Help {
     Write-Host "   -ShowLogonID" -NoNewline -ForegroundColor Green
     Write-Host " : ログオンIDを出力する (デフォルト： `$false)"
      
-    Write-Host "   -Japanese `$true" -NoNewline -ForegroundColor Green
+    Write-Host "   -Japanese" -NoNewline -ForegroundColor Green
     Write-Host " : 日本語で出力する"
 
     Write-Host
     Write-Host "その他:"
 
-    Write-Host "   -ShowContributors `$true" -NoNewline -ForegroundColor Green
+    Write-Host "   -ShowContributors" -NoNewline -ForegroundColor Green
     Write-Host " : コントリビューターの一覧表示" 
 
     Write-Host

--- a/Config/Language/ja.ps1
+++ b/Config/Language/ja.ps1
@@ -411,6 +411,10 @@ function Show-Help {
     Write-Host "   -ShowContributors" -NoNewline -ForegroundColor Green
     Write-Host " : コントリビューターの一覧表示" 
 
+    Write-Host "   -QuietLogo" -NoNewline -ForegroundColor Green
+    Write-Host " : ロゴを表示させずに実行する" 
+
+
     Write-Host
 
 }

--- a/Config/splashlogos.ps1
+++ b/Config/splashlogos.ps1
@@ -1,0 +1,26 @@
+
+$logo = @"
+██╗    ██╗███████╗██╗      █████╗ 
+██║    ██║██╔════╝██║     ██╔══██╗
+██║ █╗ ██║█████╗  ██║     ███████║
+██║███╗██║██╔══╝  ██║     ██╔══██║
+╚███╔███╔╝███████╗███████╗██║  ██║
+ ╚══╝╚══╝ ╚══════╝╚══════╝╚═╝  ╚═╝
+"@
+function output-splash() {
+    foreach ($line in $logo -split "`n") {
+        foreach ($char in $line.tochararray()) {
+            if ($([int]$char) -le 9580 -and $([int]$char) -ge 9552) {
+                Write-host -ForegroundColor Red $char -NoNewline
+            }
+            else {
+                write-host -ForegroundColor blue $char -NoNewline
+            }
+        }
+        Write-Host ""
+    }
+    Write-host "New Era of Windows Event Log Analyzer!"
+    write-host "                              by " -NoNewline
+    write-host "Yamato Security" -ForegroundColor Yellow
+}
+output-splash

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ You will need local Administrator access for live analysis.
         -UTC : 時間をUTC形式で出力する
         -HideDisplayTimezone :  タイムゾーンの表示をしない
         -ShowLogonID : ログオンIDを出力する (デフォルト：$false)
-        -Japanese $true : 日本語で出力する
+        -Japanese : 日本語で出力する
 
     その他:
-        -ShowContributors $true : コントリビューターの一覧表示
+        -ShowContributors : コントリビューターの一覧表示
 
 ## Useful Options
 

--- a/README.md
+++ b/README.md
@@ -111,21 +111,21 @@ You will need local Administrator access for live analysis.
 
 Show event ID statistics to get a grasph of what kind of events there are:
 
-    .\WELA.ps1 -EventIDStatistics $true
+    .\WELA.ps1 -EventIDStatistics
 
 Create a timeline via offline analysis outputted to a GUI in UTC time:
 
-    .\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline $true -OutputGUI $true -UTC $true
+    .\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline -OutputGUI -UTC
 
 ## 便利なオプション
 
 どんなイベントがあるのかを把握するためにイベントIDを集計する：
 
-    ./WELA.ps1 -EventIDStatistics $true
+    ./WELA.ps1 -EventIDStatistics
 
 オフライン解析でタイムラインを作成して、UTC時間でGUIで表示する：
 
-    .\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline $true -OutputGUI $true -UTC $true
+    .\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline -OutputGUI -UTC
 
 ## Screenshots (スクリーンショット)
 

--- a/WELA.ps1
+++ b/WELA.ps1
@@ -330,12 +330,12 @@ function Create-EventIDStatistics {
     $WineventFilter = @{}
     
     if ( $StartTimeline -ne "" ) { 
-        $StartTimeline = [DateTime]::ParseExact($StartTimeline, 'yyyy-MM-dd HH:mm:ss', $null) 
+        $StartTimeline = [DateTime]::ParseExact($StartTimeline, $DateFormat, $null) 
         $WineventFilter.Add( "StartTime" , $StartTimeline )   
     }
 
     if ( $EndTimeline -ne "" ) { 
-        $EndTimeline = [DateTime]::ParseExact($EndTimeline, 'yyyy-MM-dd HH:mm:ss', $null) 
+        $EndTimeline = [DateTime]::ParseExact($EndTimeline, $DateFormat, $null) 
         $WineventFilter.Add( "EndTime" , $EndTimeline )
     }
 
@@ -522,12 +522,12 @@ function Create-LogonTimeline {
     $LogServiceShutdownTimeArray = @()
     
     if ( $StartTimeline -ne "" ) { 
-        $StartTimeline = [DateTime]::ParseExact($StartTimeline, 'yyyy-MM-dd HH:mm:ss', $null) 
+        $StartTimeline = [DateTime]::ParseExact($StartTimeline, $DateFormat, $null) 
         $WineventFilter.Add( "StartTime" , $StartTimeline )   
     }
 
     if ( $EndTimeline -ne "" ) { 
-        $EndTimeline = [DateTime]::ParseExact($EndTimeline, 'yyyy-MM-dd HH:mm:ss', $null) 
+        $EndTimeline = [DateTime]::ParseExact($EndTimeline, $DateFormat, $null) 
         $WineventFilter.Add( "EndTime" , $EndTimeline )
     }
 
@@ -582,13 +582,13 @@ function Create-LogonTimeline {
             }
             
             if ( $UTC -eq $true ) {
-                $LogoffTimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+                $LogoffTimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat)
             }
             else {
-                $LogoffTimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogoffTimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $LogoffTimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $LogoffTimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, $DateFormat, $null) 
             $LogoffEvent = @( $msgTargetLogonID , $LogoffTimestampDateTime )
             $LogoffEventArray.Add( $LogoffEvent ) > $null
         }
@@ -608,13 +608,13 @@ function Create-LogonTimeline {
             }
             
             if ( $UTC -eq $true ) {
-                $LogoffTimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+                $LogoffTimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat)
             }
             else {
-                $LogoffTimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogoffTimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $LogoffTimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $LogoffTimestampDateTime = [datetime]::ParseExact($LogoffTimestampString, $DateFormat, $null) 
             $LogoffEvent = @( $msgTargetLogonID , $LogoffTimestampDateTime )
             $LogoffEventArray.Add( $LogoffEvent ) > $null
 
@@ -627,13 +627,13 @@ function Create-LogonTimeline {
             $eventXML = [xml]$event.ToXml()
 
             if ( $UTC -eq $true ) {
-                $LogServiceShutdownTimeString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+                $LogServiceShutdownTimeString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat)
             }
             else {
-                $LogServiceShutdownTimeString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogServiceShutdownTimeString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $LogServiceShutdownTimeDateTime = [datetime]::ParseExact($LogServiceShutdownTimeString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $LogServiceShutdownTimeDateTime = [datetime]::ParseExact($LogServiceShutdownTimeString, $DateFormat, $null) 
             $LogServiceShutdownTimeArray += $LogServiceShutdownTimeDateTime 
 
         }
@@ -701,13 +701,13 @@ function Create-LogonTimeline {
             $LogServiceShutdownTimeString = ""
 
             if ( $UTC -eq $true ) {
-                $LogonTimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogonTimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat) 
             }
             else {
-                $LogonTimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogonTimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $LogonTimestampDateTime = [datetime]::ParseExact($LogonTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null)
+            $LogonTimestampDateTime = [datetime]::ParseExact($LogonTimestampString, $DateFormat, $null)
 
             if ( $msgLogonType -eq "0" ) {
                 #if System startup/runtime
@@ -716,7 +716,7 @@ function Create-LogonTimeline {
 
                     if ( $LogServiceShutdownTime -gt $LogonTimestampDateTime -and $LogoffTimestampString -eq "" ) {
                        
-                        $LogoffTimestampString = $LogServiceShutdownTime.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                        $LogoffTimestampString = $LogServiceShutdownTime.ToString($DateFormat) 
                         $ElapsedTime = $LogServiceShutdownTime - $LogonTimestampDateTime
 
                     }     
@@ -734,7 +734,7 @@ function Create-LogonTimeline {
                     # If the logon ID match and the logoff date is greater than the logon date and $LogoffTimestampString is blank (to prevent skipping to an older duplicate logon id (rare case?))
                     if ( $EventIndex[0] -eq $msgTargetLogonID -and $EventIndex[1] -ge $LogonTimestampDateTime -and $LogoffTimestampString -eq "" ) {
                        
-                        $LogoffTimestampString = $EventIndex[1].ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                        $LogoffTimestampString = $EventIndex[1].ToString($DateFormat) 
                         $ElapsedTime = $EventIndex[1] - $LogonTimestampDateTime
 
                     }     
@@ -825,13 +825,13 @@ function Create-LogonTimeline {
             $msgProcessName = "-"
 
             if ( $UTC -eq $true ) {
-                $LogonTimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogonTimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat) 
             }
             else {
-                $LogonTimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $LogonTimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $LogonTimestampDateTime = [datetime]::ParseExact($LogonTimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null)
+            $LogonTimestampDateTime = [datetime]::ParseExact($LogonTimestampString, $DateFormat, $null)
             $LogoffTimestampString = $Create_LogonTimeline_NoLogoffEvent # "No logoff event"
 
             if ($msgTargetUserName[-1] -ne "$") {
@@ -1060,9 +1060,9 @@ function Create-Timeline {
         $filter = @{}
         $filter.Add("StartTime", $StartingTime)
         $filter.Add("LogName", "Security")
-        #$filter.Add("ID", "4624,4625,4672,4634,4647,4720,4732,1102,4648") #filter not working when specifying a start date..
+        #$filter.Add("ID", "4624, 4625, 4672, 4634, 4647, 4720, 4732, 1102, 4648") #filter not working when specifying a start date..
         
-        #$filter = "@{Logname=""Security"";ID=$EventIDsToAnalyze;StartTime=$yesterday;EndTime=(Get-Date)}"
+        #$filter = "@{ Logname=""Security""; ID=$EventIDsToAnalyze; StartTime=$yesterday; EndTime=(Get-Date) }"
     }
     #>
     
@@ -1078,10 +1078,10 @@ function Create-Timeline {
             }
  
             # Bug: starttime not working: can filter on IDs when 
-            #$filter = "@{Logname=""Security"";ID=$EventIDsToAnalyze}"
+            #$filter = "@{ Logname=""Security""; ID=$EventIDsToAnalyze }"
             #and $logs = iex "Get-WinEvent -FilterHashTable $filter -Oldest -ErrorAction Stop"
             #when is change to $logs Get-WinEvent -FilterHashTable $filter -Oldest -ErrorAction Stop   I get
-            #Get-WinEvent error:  Cannot bind parameter 'FilterHashtable'. Cannot convert the "@{Logname="Security";ID=4624,4625,4672,4634,4647,4720,4732,1102,4648}" value of type "System.String" to type "System.Collections.Hashtable".
+            #Get-WinEvent error:  Cannot bind parameter 'FilterHashtable'. Cannot convert the "@{ Logname="Security"; ID=4624, 4625, 4672, 4634, 4647, 4720, 4732, 1102, 4648 }" value of type "System.String" to type "System.Collections.Hashtable".
             #filter.add method gives me Get-WinEvent error:  Cannot bind parameter 'FilterHashtable'. Cannot convert the "System.Collections.Hashtable" value of type "System.String" to type "System.Collections.Hashtable". error when
             #$filter.Add("ID", $EventIDsToAnalyze) is specified.  
             #Get-WinEvent error:  There is not an event log on the localhost computer that matches "System.Collections.Hashtable". when commented out
@@ -1097,8 +1097,8 @@ function Create-Timeline {
 
     } 
     ElseIf ( $LogFile -ne "" ) {
-        $filter = "@{Path=""$LogFile"";ID=$EventIDsToAnalyze}"
-        $filter2 = "@{Path=""$LogFile""}"
+        $filter = "@{ Path=""$LogFile""; ID=$EventIDsToAnalyze }"
+        $filter2 = "@{Path = ""$LogFile"" }"
         Write-Host
         Write-Host "Creating timeline for $LogFile"
         $filesize = Format-FileSize( (get-item $LogFile).length )
@@ -1154,13 +1154,13 @@ function Create-Timeline {
             }
             
             if ( $UTC -eq $true ) {
-                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat)
             }
             else {
-                $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $TimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $TimestampDateTime = [datetime]::ParseExact($TimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $TimestampDateTime = [datetime]::ParseExact($TimestampString, $DateFormat, $null) 
             $timestamp = $event.TimeCreated.ToString($DateFormat) 
             $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
             $printMSG = "4768 - Requested Kerberos authentication ticket(TGT) to Service: $msgTargetService from User: $msgTargetUserName from Domain: $msgTargetDomainName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";
@@ -1209,13 +1209,13 @@ function Create-Timeline {
             }
             
             if ( $UTC -eq $true ) {
-                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ff")
+                $TimestampString = $event.TimeCreated.ToUniversalTime().ToString($DateFormat)
             }
             else {
-                $TimestampString = $event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss.ff") 
+                $TimestampString = $event.TimeCreated.ToString($DateFormat) 
             }
 
-            $TimestampDateTime = [datetime]::ParseExact($TimestampString, 'yyyy-MM-dd HH:mm:ss.ff', $null) 
+            $TimestampDateTime = [datetime]::ParseExact($TimestampString, $DateFormat, $null) 
             $timestamp = $event.TimeCreated.ToString($DateFormat) 
             $msgStatusReadable = Get-KerberosStatusStr $msgResultCode
             $printMSG = "4769 - Requested Kerberos service ticket to Service: $msgTargetService from User: $msgTargetUserName IPAddress: $msgIpAddress Port: $msgIpPort TicketStatus: $msgStatus($msgStatusReadable)";

--- a/WELA.ps1
+++ b/WELA.ps1
@@ -27,28 +27,28 @@
     .\WELA.ps1
 
     Output Event ID Statistics (イベントIDの集計):
-    .\WELA.ps1 -EventIDStatistics $true
+    .\WELA.ps1 -EventIDStatistics
 
     Live Analysis Timeline Generation (ライブ調査のタイムライン作成):
-    .\WELA.ps1 -LiveAnalysis $true -LogonTimeline $true
+    .\WELA.ps1 -LiveAnalysis -LogonTimeline
 
     Offline Analysis Timeline Generation (オフライン調査のタイムライン作成):
-    .\WELA.ps1 -LogFile .\Cobalt-Strike-Security.evtx -LogonTimeline $true
+    .\WELA.ps1 -LogFile .\Cobalt-Strike-Security.evtx -LogonTimeline
     
     Analyze with a GUI(GUIでの解析):
-    -OutputGUI $true
+    -OutputGUI
 
     日本語出力：
-    -Japanese $true
+    -Japanese
 
     Save Output(結果の保存):
     -SaveOutput file.txt
 
     Display in UTC time (by default, it displays in local time) (UTC時間での表示。デフォルトはローカル時間)：
-    -UTC $true
+    -UTC
 
     Show Logon IDs(Default: false)(ログオンIDの表示):
-    -ShowLogonID $true
+    -ShowLogonID
 
     .LINK
     https://github.com/Yamato-Security/WELA

--- a/WELA.ps1
+++ b/WELA.ps1
@@ -99,10 +99,15 @@ param (
     [switch]$OutputGUI,
     [switch]$OutputCSV,
     [switch]$UTC,
-    [switch]$HideTimezone
+    [switch]$HideTimezone,
+    [switch]$QuietLogo
 )
 
 $DisplayTimezone = !($HideTimezone);
+
+if (!$QuietLogo) {
+    Invoke-Expression './Config/splashlogos.ps1'
+}
 
 $ProgramStartTime = Get-Date
 


### PR DESCRIPTION
closes #41 

## 変更点

- 起動時のロゴ表示を追加
- オプションにロゴ表示を行わないフラグを追記
- 各言語のヘルプ文面にロゴ表示を行わないフラグをその他に追記

## 実行結果

- ロゴ表示を行わないフラグを付けなかった場合

> PS > .\WELA.ps1          
> ██╗    ██╗███████╗██╗      █████╗ 
> ██║    ██║██╔════╝██║     ██╔══██╗
> ██║ █╗ ██║█████╗  ██║     ███████║
> ██║███╗██║██╔══╝  ██║     ██╔══██║
> ╚███╔███╔╝███████╗███████╗██║  ██║
>  ╚══╝╚══╝ ╚══════╝╚══════╝╚═╝  ╚═╝
> New Era of Windows Event Log Analyzer!
>                               by Yamato Security
> 
> Windows Event Log Analyzer(WELA)
> バージョン: 1.0
> 作者: 田中ザック (@yamatosecurity)と大和セキュリティメンバー
> 
> 解析ソースを一つ指定して下さい：
>    -LiveAnalysis : ホストOSのログでタイムラインを作成する
>    -LogFile <path-to-logfile> : オフラインの.evtxファイルでタイムラインを作成する
> 
> 解析タイプを一つ指定して下さい:
>    -EventIDStatistics : イベントIDの集計情報を出力する
>    -LogonTimeline : ユーザログオンの簡単なタイムラインを出力する
> 
> 出力方法（デフォルト：標準出力）:
>    -SaveOutput <出力パス> : テキストファイルに出力する
>    -OutputCSV : CSVファイルに出力する
>    -OutputGUI : Out-GridView GUIに出力する
> 
> 解析オプション:
>    -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの始まりを指定する
>    -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの終わりを指定する
>    -IsDC : ドメインコントローラーのログの場合は指定して下さい
> 
> 出力オプション:
>    -USDateFormat : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
>    -EuropeDateFormat : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
>    -UTC : 時間をUTC形式で出力する。（デフォルトはローカルタイムゾーン）
>    -HideTimezone :  タイムゾーンの表示をしない
>    -ShowLogonID : ログオンIDを出力する
>    -Japanese : 日本語で出力する
> 
> その他:
>    -ShowContributors : コントリビューターの一覧表示
>    -QuietLogo : ロゴを表示させずに実行する
> 

- ロゴ表示を行わないフラグを付けた場合

> PS > .\WELA.ps1 -QuietLogo
> 
> Windows Event Log Analyzer(WELA)
> バージョン: 1.0
> 作者: 田中ザック (@yamatosecurity)と大和セキュリティメンバー
> 
> 解析ソースを一つ指定して下さい：
>    -LiveAnalysis : ホストOSのログでタイムラインを作成する
>    -LogFile <path-to-logfile> : オフラインの.evtxファイルでタイムラインを作成する
> 
> 解析タイプを一つ指定して下さい:
>    -EventIDStatistics : イベントIDの集計情報を出力する
>    -LogonTimeline : ユーザログオンの簡単なタイムラインを出力する
> 
> 出力方法（デフォルト：標準出力）:
>    -SaveOutput <出力パス> : テキストファイルに出力する
>    -OutputCSV : CSVファイルに出力する
>    -OutputGUI : Out-GridView GUIに出力する
> 
> 解析オプション:
>    -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの始まりを指定する
>    -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの終わりを指定する
>    -IsDC : ドメインコントローラーのログの場合は指定して下さい
> 
> 出力オプション:
>    -USDateFormat : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
>    -EuropeDateFormat : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
>    -UTC : 時間をUTC形式で出力する。（デフォルトはローカルタイムゾーン）
>    -HideTimezone :  タイムゾーンの表示をしない
>    -ShowLogonID : ログオンIDを出力する
>    -Japanese : 日本語で出力する
> 
> その他:
>    -ShowContributors : コントリビューターの一覧表示
>    -QuietLogo : ロゴを表示させずに実行する
> 
> 