### PR TITLE
fixed output error #69

### DIFF
--- a/WELA.ps1
+++ b/WELA.ps1
@@ -247,7 +247,7 @@ if ( $LiveAnalysis -eq $true -and ($LogFile -ne "" -or $LogDirectory -ne "")) {
 }
 
 # Show-Helpは各言語のModuleに移動したためShow-Help関数は既に指定済みの言語の内容となっているため言語設定等の参照は行わない
-if ( $LiveAnalysis -eq $false -and $RemoteLiveAnalysis -eq $false -and $LogFile -eq "" -and $EventID_Statistics -eq $false -and $LogonTimeline -eq $false -and $AccountInformation -eq $false -and $AnalyzeNTLM_UsageBasic -eq $false -and $AnalyzeNTLM_UsageDetailed -eq $false) {
+if ( $LiveAnalysis -eq $false -and $RemoteLiveAnalysis -eq $false -and $LogFile -eq "" -and $SecurityEventID_Statistics -eq $false -and $SecurityLogonTimeline -eq $false -and $AccountInformation -eq $false -and $AnalyzeNTLM_UsageBasic -eq $false -and $AnalyzeNTLM_UsageDetailed -eq $false) {
 
     Show-Help
     exit


### PR DESCRIPTION
closes #69 

## reason

-  condition statement of call show-help is undefined variable

## result 

```
PS >.\WELA.ps1

db   d8b   db d88888b db       .d8b.  
88   I8I   88 88'     88      d8' 8b 
88   I8I   88 88ooooo 88      88ooo88 Y8   I8I   88 88~~~~~ 88      88~~~88 
8b  d8'8b d8' 88.     88booo. 88   88  8b8'' 8d8''  Y88888P Y88888P YP   YP 

The Swiss Army Knife for Windows Event Logs!
                              by Yamato Security

Windows Event Log Analyzer(WELA) ゑ羅(ウェラ)
バージョン: 1.0
作者: 田中ザック (@yamatosecurity)と大和セキュリティメンバー

解析ソースを一つ指定して下さい：
   -LiveAnalysis : ホストOSのログを解析する
   -LogFile <ログファイルのパス> : オフラインの.evtxファイルを解析する     
   -LogDirectory <ログファイルのディレクトリのパス> (未完成) : 複数のオフラインの.evtxファイルを解析する
   -RemoteLiveAnalysis : リモートマシンのログでタイムラインを作成する      

解析タイプを一つ指定して下さい:
   -AnalyzeNTLM_UsageBasic : NTLM Operationalログを解析し、NTLM認証の使用を簡潔に出力する
   -AnalyzeNTLM_UsageDetailed : NTLM Operationalログを解析し、NTLM認証の使 用を詳細に出力する
   -SecurityEventID_Statistics : セキュリティログのイベントIDの集計情報を出力する
   -EasyToReadSecurityLogonTimeline : セキュリティログからユーザログオンの
読みやすいタイムラインを出力する
   -SecurityLogonTimeline : セキュリティログからユーザログオンの簡単なタイ ムラインを出力する

解析オプション:
   -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの始まりを指定する 
   -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの終わりを指定する

-SecurityLogonTimelineの解析オプション:
   -IsDC : ドメインコントローラーのログの場合は指定して下さい
   -UseDetectRule <preset rule | path-to-ruledirectory>(Default:preset rule='0')：検知ルールに該当するイベントの出力を行う
   preset rule| 0:None 1: DeepBlueCLI 2:SIGMA all:all-preset

出力方法（デフォルト：標準出力）:
   -SaveOutput <出力パス> : テキストファイルに出力する
   -OutputCSV : CSVファイルに出力する
   -OutputGUI : Out-GridView GUIに出力する

出力オプション:
   -USDateFormat : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
   -EuropeDateFormat : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
   -UTC : 時間をUTC形式で出力する。（デフォルトはローカルタイムゾーン）    
   -English : 英語で出力する
   -Japanese : 日本語で出力する

-LogonTimelineの出力オプション:
   -HideTimezone :  タイムゾーンの表示をしない
   -ShowLogonID : ログオンIDを出力する

その他:
   -ShowContributors : コントリビューターの一覧表示
   -QuietLogo : ロゴを表示させずに実行する
```