### PR TITLE
removed unnecessary mp-preference

### DIFF
--- a/WELA.ps1
+++ b/WELA.ps1
@@ -374,8 +374,4 @@ if ($ruleStack.Count -ne 0) {
 }
 
 Remove-Variable ruleStack
-$isAdmin = Check-Administrator
-if ( $isAdmin -eq $true -and ($UseDetectRules -eq "2" -or $UseDetectRules.toupper() -eq "all")) {
-    Set-MpPreference -DisableRealTimeMonitoring $false;
-}
 Set-ExecutionPolicy $exectionpolicy -scope Process


### PR DESCRIPTION
不要なmp-preferenceがあったため削除。
元々はmp-preferenceでWindows DefenderがSIGMAルールを検知してしまう状況があったため投入したが
効果がなかったため