### PR TITLE
Hotfix/options wrong#79 #81

### DIFF
--- a/Analyzers/NTLM-Operational-Usage.ps1
+++ b/Analyzers/NTLM-Operational-Usage.ps1
@@ -132,7 +132,7 @@ function Analyze-NTLMOperationalBasic {
     }
     Write-Host "$Create_EventIDStatistics_LastEvent $LastEventTime"
 
-    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest
+    $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter  #Load event logs into memory.
     $eventlist = @{}
     $8001_NumberOfLogs = 0
     $8002_NumberOfLogs = 0

--- a/Analyzers/Security-AuthenticationSummary.ps1
+++ b/Analyzers/Security-AuthenticationSummary.ps1
@@ -106,7 +106,7 @@ function Create-SecurityAuthenticationSummary {
     initialize_AuthenticationSummary
 
     $WineventFilter.Add( "Path", $filePath)
-    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest -ErrorAction SilentlyContinue #Load event logs into memory.
+    $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter  #Load event logs into memory.
 
     If ( $logs.length -eq 0 ) {
         Write-Host $Info_GetEventNoMatch -ForegroundColor Green

--- a/Analyzers/Security-AuthenticationSummary.ps1
+++ b/Analyzers/Security-AuthenticationSummary.ps1
@@ -106,7 +106,7 @@ function Create-SecurityAuthenticationSummary {
     initialize_AuthenticationSummary
 
     $WineventFilter.Add( "Path", $filePath)
-    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest #Load event logs into memory.
+    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest -ErrorAction SilentlyContinue #Load event logs into memory.
 
     If ( $logs.length -eq 0 ) {
         Write-Host $Info_GetEventNoMatch -ForegroundColor Green

--- a/Analyzers/Security-EventID_Statistics.ps1
+++ b/Analyzers/Security-EventID_Statistics.ps1
@@ -33,7 +33,7 @@
     }
 
     $WineventFilter.Add( "Path", $filePath ) 
-    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest
+    $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter  #Load event logs into memory.
     $eventlist = @{}
     $TotalNumberOfLogs = 0
 

--- a/Analyzers/Security-LogonTimeline.ps1
+++ b/Analyzers/Security-LogonTimeline.ps1
@@ -165,7 +165,7 @@ function Create-SecurityLogonTimeline {
     Write-Host $Create_LogonTimeline_PleaseWait
     Write-Host ""
 
-    $logs = Get-WinEvent -FilterHashtable $WineventFilter -Oldest #Load event logs into memory.
+    $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter #Load event logs into memory.
     $eventlist = @{}
 
     [System.Collections.ArrayList]$LogoffEventArray = @()

--- a/README-English.md
+++ b/README-English.md
@@ -40,24 +40,27 @@ You will need local Administrator access for live analysis.
 
 ```powershell
     Analysis Source (Specify one):
-        -LiveAnalysis : Creates a timeline based on the live host's log
-        -LogFile <path-to-logfile> : Creates a timelime from an offline .evtx file
+        -LiveAnalysis : Analyze logs from the live host
+        -LogFile <path-to-logfile> : Analyze an offline .evtx file
         -LogDirectory <path-to-logfiles> (Warning: not fully implemented.) : Analyze offline .evtx files
         -RemoteLiveAnalysis : Creates a timeline based on the remote host's log
 
     Analysis Type (Specify one):
         -AnalyzeNTLM_UsageBasic : Returns basic NTLM usage based on the NTLM Operational log
         -AnalyzeNTLM_UsageDetailed : Returns detailed NTLM usage based on the NTLM Operational log
-        -EventID_Statistics : Output event ID statistics
-        -LogonTimeline : Output a condensed timeline of user logons based on the Security log
+        -SecurityEventID_Statistics : Output Security log event ID statistics
+        -EasyToReadSecurityLogonTimeline : Output a very easy-to-read timeline of user logons based on the Security log
+        -SecurityLogonTimeline : Output a condensed timeline of user logons based on the Security log
         -SecurityAuthenticationSummary : Output a summary of authentication events for each logon type based on the Security log
 
     Analysis Options:
         -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : Specify the start of the timeline
         -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : Specify the end of the timeline
 
-    -LogonTimeline Analysis Options:
+    -SecurityLogonTimeline Analysis Options:
         -IsDC : Specify if the logs are from a DC
+        -UseDetectRule <preset-rule | path-to-ruledirectory>(Default: preset-rule='0')：Specify detected event output on Rule Base
+        preset-rule| 0:None 1: DeepBlueCLI 2:SIGMA all:all-preset
 
     Output Types (Default: Standard Output):
         -SaveOutput <outputfile-path> : Output results to a text file
@@ -68,6 +71,7 @@ You will need local Administrator access for live analysis.
         -USDateFormat : Output the dates in MM-DD-YYYY format (Default: YYYY-MM-DD)
         -EuropeDateFormat : Output the dates in DD-MM-YYYY format (Default: YYYY-MM-DD)
         -UTC : Output in UTC time (default is the local timezone)
+        -English : Output in English
         -Japanese : Output in Japanese
 
     -LogonTimeline Output Options:

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -40,24 +40,27 @@ Windows Powershell 5.1で動作確認済みですが、以前のバージョン�
 
 ```powershell
     解析ソースを一つ指定して下さい：
-        -LiveAnalysis : ホストOSのログでタイムラインを作成する
-        -LogFile <ログファイルのパス> : オフラインの.evtxファイルでタイムラインを作成する
+        -LiveAnalysis : ホストOSのログを解析する
+        -LogFile <ログファイルのパス> : オフラインの.evtxファイルを解析する
         -LogDirectory <ログファイルのディレクトリのパス> (未完成) : 複数のオフラインの.evtxファイルを解析する
         -RemoteLiveAnalysis : リモートマシンのログでタイムラインを作成する
 
     解析タイプを一つ指定して下さい:
         -AnalyzeNTLM_UsageBasic : NTLM Operationalログを解析し、NTLM認証の使用を簡潔に出力する
         -AnalyzeNTLM_UsageDetailed : NTLM Operationalログを解析し、NTLM認証の使用を詳細に出力する
-        -EventIDStatistics : イベントIDの集計情報を出力する
-        -LogonTimeline : ユーザログオンの簡単なタイムラインを出力する
-        -SecurityAuthenticationSummary : ログオンタイプごとの集計情報を出力する
+        -SecurityEventID_Statistics : セキュリティログのイベントIDの集計情報を出力する
+        -EasyToReadSecurityLogonTimeline : セキュリティログからユーザログオンの読みやすいタイムラインを出力する
+        -SecurityLogonTimeline : セキュリティログからユーザログオンの簡単なタイムラインを出力する
+        -SecurityAuthenticationSummary : セキュリティログからログオンタイプごとの集計情報を出力する
 
     解析オプション:
         -StartTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの始まりを指定する
         -EndTimeline "<YYYY-MM-DD HH:MM:SS>" : タイムラインの終わりを指定する
 
-    -LogonTimelineの解析オプション:
+    -SecurityLogonTimelineの解析オプション:
         -IsDC : ドメインコントローラーのログの場合は指定して下さい
+        -UseDetectRule <preset rule | path-to-ruledirectory>(Default:preset rule='0')：検知ルールに該当するイベントの出力を行う
+        preset rule| 0:None 1: DeepBlueCLI 2:SIGMA all:all-preset
 
     出力方法（デフォルト：標準出力）:
         -SaveOutput <出力パス> : テキストファイルに出力する
@@ -68,6 +71,7 @@ Windows Powershell 5.1で動作確認済みですが、以前のバージョン�
         -USDateFormat : 日付をMM-DD-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
         -EuropeDateFormat : 日付をDD-MM-YYYY形式で出力する (デフォルト： YYYY-MM-DD)
         -UTC : 時間をUTC形式で出力する。（デフォルトはローカルタイムゾーン）
+        -English : 英語で出力する
         -Japanese : 日本語で出力する
 
     -LogonTimelineの出力オプション:


### PR DESCRIPTION
closes #79 , #81 

- 実行オプションの変更にreadmeの修正が対応できていなかったので、readmeを現在のWELAのオプションになるように修正(#79)
- ログ情報取得の際にSecurity-Authentication.ps1でログ情報取得時にエラーが出ても継続して読み込むようにオプションを追加(#81 )