### PR TITLE
fix readme commands.

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -94,12 +94,12 @@ Windows Powershell 5.1で動作確認済みですが、以前のバージョン�
 
 どのようなイベントがあるかを把握するためにまずイベントIDを集計する：
 ```powershell
-./WELA.ps1 -LogFile .\Security.evtx -EventIDStatistics
+./WELA.ps1 -LogFile .\Security.evtx -EventID_Statistics
 ```
 
 オフライン解析でタイムラインを作成して、UTC時間でGUIで表示する：
 ```powershell
-.\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline -OutputGUI -UTC
+.\WELA.ps1 -LogFile .\Security.evtx -SecurityLogonTimeline -OutputGUI -UTC
 ```
 
 NTLM認証を無効にする前に使用を確認する:

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ You will need local Administrator access for live analysis.
 
 ### Show event ID statistics to get a grasp of what kind of events there are:
 ```powershell
-./WELA.ps1 -LogFile .\Security.evtx -EventIDStatistics
+./WELA.ps1 -LogFile .\Security.evtx -EventID_Statistics
 ```
 
 ### Create a timeline via offline analysis outputted to a GUI in UTC time:
 ```powershell
-.\WELA.ps1 -LogFile .\Security.evtx -LogonTimeline -OutputGUI -UTC
+.\WELA.ps1 -LogFile .\Security.evtx -SecurityLogonTimeline -OutputGUI -UTC
 ```
 
 ### Analyze NTLM Operational logs for NTLM usage before disabling it:


### PR DESCRIPTION
[便利な機能](https://github.com/fukusuket/WELA/blob/fix-readme-20221213/README-Japanese.md#%E4%BE%BF%E5%88%A9%E3%81%AA%E6%A9%9F%E8%83%BD)のコマンド例に実在しないコマンドが記載されていたようなので、以下変更をしました。
- `EventIDStatistics` -> `EventID_Statistics`
- `LogonTimeline` -> `SecurityLogonTimeline`

(こちらの仕様勘違いでしたら、すみません！🙇)