### PR TITLE
fixed result error in easytoreadsecuirtylogontimeline option when target event record number is 0

### DIFF
--- a/Analyzers/NTLM-Operational-Usage.ps1
+++ b/Analyzers/NTLM-Operational-Usage.ps1
@@ -56,7 +56,7 @@ function SecureChannelTypeLookup ($secureChannelType) {
         "5" { $return = "Uas Server (Secure channel between a LAN Manager server to DC. Shouldn't be used.)" }
         "6" { $return = "Server (Secure channel from backup DC to primary DC.)" }
         "7" { $return = "Cdc (Secure channel from Read-Only DC (RODC) to DC.)" }
-        else { $return = "Unknown."}
+        else { $return = "Unknown." }
     }
     return  $return
 }
@@ -103,8 +103,8 @@ function Analyze-NTLMOperationalBasic {
     Write-Host
 
     #Check to see if log is empty
-    try { $newestEvent = Get-WinEvent -FilterHashtable $WineventFilter -MaxEvents 1 -ErrorAction Stop }
-    catch [Exception]{
+    try { $newestEvent = Get-WinEvent -FilterHashtable $WineventFilter -MaxEvents 1 -ErrorAction SilentlyContinue }
+    catch [Exception] {
         if ($_.Exception -match "No events were found that match the specified selection criteria") {
             Write-Host $Error_NoEventsFound
             Write-Host
@@ -379,8 +379,8 @@ function Analyze-NTLMOperationalDetailed {
     Write-Host
 
     #Check to see if log is empty
-    try { $newestEvent = Get-WinEvent -FilterHashtable $WineventFilter -MaxEvents 1 -ErrorAction Stop }
-    catch [Exception]{
+    try { $newestEvent = Get-WinEvent -FilterHashtable $WineventFilter -MaxEvents 1 -ErrorAction SilentlyContinue }
+    catch [Exception] {
         if ($_.Exception -match "No events were found that match the specified selection criteria") {
             Write-Host $Error_NoEventsFound
             Write-Host
@@ -500,8 +500,8 @@ function Analyze-NTLMOperationalDetailed {
             }
             
             $tempoutput = [Ordered]@{ 
-                "RemoteServer"     = $8004_msgSChannelName.ToLower() ;
-                "Username"              = $8004_msgUserName.ToLower() ;
+                "RemoteServer" = $8004_msgSChannelName.ToLower() ;
+                "Username"     = $8004_msgUserName.ToLower() ;
                 "SourceClient" = $8004_msgWorkstationName.ToLower()
 
             }

--- a/Analyzers/Security-LogonTimeline.ps1
+++ b/Analyzers/Security-LogonTimeline.ps1
@@ -1370,8 +1370,17 @@ function Create-EasyToReadSecurityLogonTimeline {
     }
 
     $GoodData = $TotalPiecesOfData - $LogNoise
-    $LogEventDataReduction = [math]::Round( ( ($TotalLogs - $AlertedEvents) / $TotalLogs * 100 ), 1 )
-    $PercentOfLogNoise = [math]::Round( ( $LogNoise / $TotalPiecesOfData * 100 ), 1 )
+    $LogEventDataReduction = 0
+
+    if ($TotalLogs -ne 0) {
+        $LogEventDataReduction = [math]::Round( ( ($TotalLogs - $AlertedEvents) / $TotalLogs * 100 ), 1 )
+    }
+
+    $PercentOfLogNoise = 0
+    if ($TotalPiecesOfData -ne 0) {
+        $PercentOfLogNoise = [math]::Round( ( $LogNoise / $TotalPiecesOfData * 100 ), 1 )
+    }
+
     $ProgramEndTime = Get-Date
     $TotalRuntime = [math]::Round(($ProgramEndTime - $ProgramStartTime).TotalSeconds)
 

--- a/Analyzers/Security-LogonTimeline.ps1
+++ b/Analyzers/Security-LogonTimeline.ps1
@@ -680,7 +680,7 @@ function Create-EasyToReadSecurityLogonTimeline {
     Write-Host
 
     try {
-        $logs = iex "Get-WinEvent $filter -Oldest -ErrorAction Stop"
+        $logs = Invoke-Expression "Get-WinEvent $filter -Oldest -ErrorAction Stop"
 
     }
     catch {
@@ -1287,8 +1287,7 @@ function Create-EasyToReadSecurityLogonTimeline {
                 Else {
                     Write-Output "$timestamp $printMSG" | Out-File $SaveOutput -Append
                 }      
-            }   
-       
+            }
         }  
 
         #Logon using explicit credentials

--- a/Analyzers/Security-LogonTimeline.ps1
+++ b/Analyzers/Security-LogonTimeline.ps1
@@ -680,7 +680,7 @@ function Create-EasyToReadSecurityLogonTimeline {
     Write-Host
 
     try {
-        $logs = Invoke-Expression "Get-WinEvent $filter -Oldest -ErrorAction Stop"
+        $logs = Invoke-Expression "Get-WinEvent $filter -Oldest -ErrorAction SilentlyContinue"
 
     }
     catch {

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -94,7 +94,7 @@ Windows Powershell 5.1で動作確認済みですが、以前のバージョン�
 
 どのようなイベントがあるかを把握するためにまずイベントIDを集計する：
 ```powershell
-./WELA.ps1 -LogFile .\Security.evtx -EventID_Statistics
+./WELA.ps1 -LogFile .\Security.evtx -SecurityEventID_Statistics
 ```
 
 オフライン解析でタイムラインを作成して、UTC時間でGUIで表示する：

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You will need local Administrator access for live analysis.
 
 ### Show event ID statistics to get a grasp of what kind of events there are:
 ```powershell
-./WELA.ps1 -LogFile .\Security.evtx -EventID_Statistics
+./WELA.ps1 -LogFile .\Security.evtx -SecurityEventID_Statistics
 ```
 
 ### Create a timeline via offline analysis outputted to a GUI in UTC time:

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ You will need local Administrator access for live analysis.
     Analysis Type (Specify one):
         -AnalyzeNTLM_UsageBasic : Returns basic NTLM usage based on the NTLM Operational log
         -AnalyzeNTLM_UsageDetailed : Returns detailed NTLM usage based on the NTLM Operational log
-        -EventID_Statistics : Output event ID statistics
-        -LogonTimeline : Output a condensed timeline of user logons based on the Security log
+        -SecurityEventID_Statistics : Output event ID statistics
+        -EasyToReadSecurityLogonTimeline : Output essy to read event ID statics
+        -SecurityLogonTimeline : Output a condensed timeline of user logons based on the Security log
         -SecurityAuthenticationSummary : Output a summary of authentication events for each logon type based on the Security log
 
     Analysis Options:

--- a/WELA.ps1
+++ b/WELA.ps1
@@ -272,7 +272,7 @@ if ( $LiveAnalysis -eq $true -and ($LogFile -ne "" -or $LogDirectory -ne "")) {
 }
 
 # Show-Helpは各言語のModuleに移動したためShow-Help関数は既に指定済みの言語の内容となっているため言語設定等の参照は行わない
-if ( $LiveAnalysis -eq $false -and $RemoteLiveAnalysis -eq $false -and $LogFile -eq "" -and $SecurityEventID_Statistics -eq $false -and $SecurityLogonTimeline -eq $false -and $AccountInformation -eq $false -and $AnalyzeNTLM_UsageBasic -eq $false -and $AnalyzeNTLM_UsageDetailed -eq $false -and $SecurityAuthenticationSummary -eq $false) {
+if ( $LiveAnalysis -eq $false -and $RemoteLiveAnalysis -eq $false -and $LogFile -eq "" -and $LogDirectory -eq "" -and $SecurityEventID_Statistics -eq $false -and $SecurityLogonTimeline -eq $false -and $AccountInformation -eq $false -and $AnalyzeNTLM_UsageBasic -eq $false -and $AnalyzeNTLM_UsageDetailed -eq $false -and $SecurityAuthenticationSummary -eq $false) {
 
     Show-Help
     exit
@@ -330,14 +330,12 @@ if ( $LiveAnalysis -eq $true -or $RemoteLiveAnalysis -eq $true ) {
 }
 # -LogDirectory
 elseif ( $LogDirectory -ne "" ) {
-
     if ($LogFile -ne "") {
         Write-Host
         Write-Host $Error_InCompatible_LogDirAndFile -ForegroundColor White -BackgroundColor Red
         Write-Host 
         exit
     }
-    
     Get-ChildItem -Filter *.evtx -Recurse -Path $LogDirectory | ForEach-Object { [void]$evtxFiles.Add($_.FullName) }
 }
 
@@ -393,7 +391,7 @@ if ($ruleStack.Count -ne 0) {
         $WineventFilter = @{}
         $WineventFilter.Add( "Path", $LogFile ) 
         # write-host "execute rule to $LogFile"
-        $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter -RemoteComputerInfo $RemoteComputerInfo
+        $logs = Get-WinEventWithFilter -WinEventFilter $WineventFilter -RemoteComputerInfo $RemoteComputerInfo -ErrorAction SilentlyContinue
         foreach ($rule in $ruleStack.keys) {
             #write-host "execute rule:$rule"
             Invoke-Command -scriptblock $ruleStack[$rule] -ArgumentList @($logs)


### PR DESCRIPTION
## What Changed

- fixed result error in easytoreadsecuirtylogontimeline option when target event record number is 0

## Evidence

```powershell
> .\WELA.ps1 -LogFile ..\hayabusa-sample-evtx\DeepBlueCLI\disablestop-eventlog.evtx -EasyToReadSecurityLogonTimeline -q                              
Creating timeline for ..\hayabusa-sample-evtx\DeepBlueCLI\disablestop-eventlog.evtx
File Size: 68.00 kB
Please be patient. It should take approximately: 0 hours 0 minutes 0 seconds


Total analyzed logs: 0
Useless logs: 0
Alerted events: 0
Log event data reduction: 0%

Useful Data in filtered logs: 0
Noisy Data in filtered logs: 0
Log Noise: 0%

Processing time: 0 hours 0 minutes 0 seconds
```